### PR TITLE
Feature/button styling 280

### DIFF
--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -51,11 +51,11 @@ exports[`button matches wrapper snapshot: wrapper mount 1`] = `
 }
 
 .emotion-0:focus {
-  position: absolute;
+  position: relative;
   top: 2px;
   background-color: #006435;
   outline: 3px solid #ffbf47;
-  box-shadow: none;
+  box-shadow: 0 0px 0;
 }
 
 .emotion-0 svg {
@@ -139,11 +139,11 @@ exports[`button should render a disabled button: disabled button 1`] = `
 }
 
 .emotion-0:focus {
-  position: absolute;
+  position: relative;
   top: 2px;
   background-color: #006435;
   outline: 3px solid #ffbf47;
-  box-shadow: none;
+  box-shadow: 0 0px 0;
 }
 
 .emotion-0 svg {

--- a/components/button/src/__snapshots__/test.js.snap
+++ b/components/button/src/__snapshots__/test.js.snap
@@ -46,8 +46,16 @@ exports[`button matches wrapper snapshot: wrapper mount 1`] = `
   margin-bottom: 15px;
 }
 
+.emotion-0:hover {
+  background-color: #006435;
+}
+
 .emotion-0:focus {
+  position: absolute;
+  top: 2px;
+  background-color: #006435;
   outline: 3px solid #ffbf47;
+  box-shadow: none;
 }
 
 .emotion-0 svg {
@@ -126,8 +134,16 @@ exports[`button should render a disabled button: disabled button 1`] = `
   margin-bottom: 15px;
 }
 
+.emotion-0:hover {
+  background-color: #006435;
+}
+
 .emotion-0:focus {
+  position: absolute;
+  top: 2px;
+  background-color: #006435;
   outline: 3px solid #ffbf47;
+  box-shadow: none;
 }
 
 .emotion-0 svg {

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -43,11 +43,11 @@ const StyledButton = styled('button')(
       backgroundColor: GREEN,
     },
     ':focus': {
-      position: 'absolute',
+      position: 'relative',
       top: '2px',
       backgroundColor: GREEN,
       outline: `3px solid ${YELLOW}`,
-      boxShadow: 'none',
+      boxShadow: '0 0px 0',
     },
     // TODO: avoid cascade
     ' svg': {

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -13,6 +13,7 @@ import { NTA_LIGHT, SPACING } from '@govuk-react/constants';
 import {
   BUTTON_COLOUR,
   BUTTON_COLOUR_DARKEN_15,
+  GREEN,
   WHITE,
   YELLOW,
 } from 'govuk-colours';
@@ -38,8 +39,15 @@ const StyledButton = styled('button')(
     textDecoration: 'none',
     WebkitAppearance: 'none',
     WebkitFontSmoothing: 'antialiased',
+    ':hover': {
+      backgroundColor: GREEN,
+    },
     ':focus': {
+      position: 'absolute',
+      top: '2px',
+      backgroundColor: GREEN,
       outline: `3px solid ${YELLOW}`,
+      boxShadow: 'none',
     },
     // TODO: avoid cascade
     ' svg': {


### PR DESCRIPTION
Copied hover, active, focus button pseudo states from official GDS button at: https://govuk-elements.herokuapp.com/buttons/

   ```
':hover': {
      backgroundColor: '#00692f',
      color: WHITE,
    },
    ':focus': {
      color: WHITE,
      backgroundColor: '#00692f',
      outline: `3px solid ${YELLOW}`,
    },
    ':active': {
      position: 'relative',
      top: '2px',
      boxShadow: `0 0 0 ${BUTTON_COLOUR}`,
      WebkitBoxShadow: `0 0 0 ${BUTTON_COLOUR}`,
      MozBoxShadow: `0 0 0 ${BUTTON_COLOUR}`,
    },
```

**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged

closes #280 