### PR TITLE
Allow defaultProp `objects` render in api-docs

### DIFF
--- a/components/back-link/README.md
+++ b/components/back-link/README.md
@@ -25,6 +25,6 @@ With custom click handler
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `onClick` |  | undefined | func | Custom function to run when the `onClick` event is fired
+ `onClick` |  | ```undefined``` | func | Custom function to run when the `onClick` event is fired
 
 

--- a/components/breadcrumb/README.md
+++ b/components/breadcrumb/README.md
@@ -42,6 +42,6 @@ const AnchorTag = asAnchor('a');
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | Breadcrumb contents
+ `children` | true | `````` | node | Breadcrumb contents
 
 

--- a/components/button/README.md
+++ b/components/button/README.md
@@ -34,9 +34,9 @@ import { ButtonArrow } from '@govuk-react/icons';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` |  | 'Button' | node | Button text
- `disabled` |  | false | bool | Renders a disabled button if set to true
- `icon` |  | undefined | node | Button icon
- `start` |  | false | bool | Renders a large button if set to true
+ `children` |  | ```'Button'``` | node | Button text
+ `disabled` |  | ```false``` | bool | Renders a disabled button if set to true
+ `icon` |  | ```undefined``` | node | Button icon
+ `start` |  | ```false``` | bool | Renders a large button if set to true
 
 

--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -34,7 +34,7 @@ Checkbox preselected & disabled
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | Text content for checkbox
- `className` |  | undefined | string | CSS Classname for outermost container
+ `children` | true | `````` | node | Text content for checkbox
+ `className` |  | ```undefined``` | string | CSS Classname for outermost container
 
 

--- a/components/date-input/README.md
+++ b/components/date-input/README.md
@@ -37,8 +37,8 @@ Date with hint text & error
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `errorText` |  | undefined | string | Error text
- `hintText` |  | undefined | string | Optional hint text
+ `children` | true | `````` | node | 
+ `errorText` |  | ```undefined``` | string | Error text
+ `hintText` |  | ```undefined``` | string | Optional hint text
 
 

--- a/components/document-footer-metadata/README.md
+++ b/components/document-footer-metadata/README.md
@@ -76,8 +76,8 @@ const otherData = [
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `from` |  | undefined | arrayOf[object Object] | Array of JSX nodes to render underneath the `from:` title
- `other` |  | undefined | arrayOf[object Object] | Array of Objects for any additional items, each object should contain an `id`, `title` and `content` property
- `partOf` |  | undefined | arrayOf[object Object] | Array of JSX nodes to render underneath the `part of:` title
+ `from` |  | ```undefined``` | arrayOf[object Object] | Array of JSX nodes to render underneath the `from:` title
+ `other` |  | ```undefined``` | arrayOf[object Object] | Array of Objects for any additional items, each object should contain an `id`, `title` and `content` property
+ `partOf` |  | ```undefined``` | arrayOf[object Object] | Array of JSX nodes to render underneath the `part of:` title
 
 

--- a/components/file-upload/README.md
+++ b/components/file-upload/README.md
@@ -48,9 +48,9 @@ const meta = {
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `acceptedFormats` |  | undefined | string | 
- `children` | true |  | node | 
- `hint` |  | undefined | string | Optional hint text
- `meta` |  | {} | shape[object Object] | Final form meta object, pending adjustment/removal
+ `acceptedFormats` |  | ```undefined``` | string | 
+ `children` | true | `````` | node | 
+ `hint` |  | ```undefined``` | string | Optional hint text
+ `meta` |  | ```{}``` | shape[object Object] | Final form meta object, pending adjustment/removal
 
 

--- a/components/grid-row/README.md
+++ b/components/grid-row/README.md
@@ -12,6 +12,6 @@ GridRow
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
+ `children` | true | `````` | node | 
 
 

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -52,7 +52,7 @@ Props pass through
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `level` |  | 1 | number | Semantic heading level value between 1 and 6
- `size` |  | undefined | enumObject.keys(FONT_SIZES) | Visual size level, accepts   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XSMALL`
+ `level` |  | ```1``` | number | Semantic heading level value between 1 and 6
+ `size` |  | ```undefined``` | enumObject.keys(FONT_SIZES) | Visual size level, accepts   `XLARGE`, `LARGE`, `MEDIUM`, `SMALL`, `XSMALL`
 
 

--- a/components/hidden-text/README.md
+++ b/components/hidden-text/README.md
@@ -25,6 +25,6 @@ import Paragraph from '@govuk-react/paragraph';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `summaryText` |  | '' | string | 
+ `summaryText` |  | ```''``` | string | 
 
 

--- a/components/input-field/README.md
+++ b/components/input-field/README.md
@@ -54,9 +54,9 @@ Input with hint text & error
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `hint` |  | null | string | 
- `input` |  | {} | shape[object Object] | 
- `meta` |  | {} | shape[object Object] | 
+ `children` | true | `````` | node | 
+ `hint` |  | ```null``` | string | 
+ `input` |  | ```{}``` | shape[object Object] | 
+ `meta` |  | ```{}``` | shape[object Object] | 
 
 

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -23,6 +23,6 @@ Simple
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `type` |  | 'text' | string | HTML `<Input />` type
+ `type` |  | ```'text'``` | string | HTML `<Input />` type
 
 

--- a/components/inset-text/README.md
+++ b/components/inset-text/README.md
@@ -36,6 +36,6 @@ import Paragraph from '@govuk-react/paragraph';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `isNarrow` |  | false | bool | Renders a narrow border following GDS guides if set to true
+ `isNarrow` |  | ```false``` | bool | Renders a narrow border following GDS guides if set to true
 
 

--- a/components/list-navigation/README.md
+++ b/components/list-navigation/README.md
@@ -53,7 +53,7 @@ const AnchorLink = asAnchor(Link);
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | List navigation content
- `listStyleType` |  | undefined | string | CSS value for `list-style-type`
+ `children` | true | `````` | node | List navigation content
+ `listStyleType` |  | ```undefined``` | string | CSS value for `list-style-type`
 
 

--- a/components/loading-box/README.md
+++ b/components/loading-box/README.md
@@ -12,13 +12,13 @@ LoadingBox
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `backgroundColor` |  | WHITE | string | 
- `backgroundColorOpacity` |  | 0.85 | number | 
- `children` | true |  | node | 
- `loading` |  | false | bool | 
- `spinnerColor` |  | BLACK | string | 
- `timeIn` |  | 800 | number | 
- `timeOut` |  | 200 | number | 
- `title` |  | undefined | string | 
+ `backgroundColor` |  | ```WHITE``` | string | 
+ `backgroundColorOpacity` |  | ```0.85``` | number | 
+ `children` | true | `````` | node | 
+ `loading` |  | ```false``` | bool | 
+ `spinnerColor` |  | ```BLACK``` | string | 
+ `timeIn` |  | ```800``` | number | 
+ `timeOut` |  | ```200``` | number | 
+ `title` |  | ```undefined``` | string | 
 
 

--- a/components/multi-choice/README.md
+++ b/components/multi-choice/README.md
@@ -30,9 +30,9 @@ import Radio from '@govuk-react/radio';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `hint` |  | undefined | string | 
- `label` | true |  | node | 
- `meta` |  | {} | shape[object Object] | 
+ `children` | true | `````` | node | 
+ `hint` |  | ```undefined``` | string | 
+ `label` | true | `````` | node | 
+ `meta` |  | ```{}``` | shape[object Object] | 
 
 

--- a/components/ordered-list/README.md
+++ b/components/ordered-list/README.md
@@ -40,6 +40,6 @@ import ListItem from '@govuk-react/list-item';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `listStyleType` |  | undefined | string | CSS value for `list-style-type`
+ `listStyleType` |  | ```undefined``` | string | CSS value for `list-style-type`
 
 

--- a/components/panel/README.md
+++ b/components/panel/README.md
@@ -12,8 +12,8 @@ Panel
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `className` |  | undefined | string | 
- `panelBody` |  | undefined | string | 
- `panelTitle` | true |  | string | 
+ `className` |  | ```undefined``` | string | 
+ `panelBody` |  | ```undefined``` | string | 
+ `panelTitle` | true | `````` | string | 
 
 

--- a/components/paragraph/README.md
+++ b/components/paragraph/README.md
@@ -33,7 +33,7 @@ As supporting text
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` |  | '' | node | Text content supporting markdown
- `supportingText` |  | false | bool | Is this paragraph supporting text for another element?
+ `children` |  | ```''``` | node | Text content supporting markdown
+ `supportingText` |  | ```false``` | bool | Is this paragraph supporting text for another element?
 
 

--- a/components/phase-banner/README.md
+++ b/components/phase-banner/README.md
@@ -12,7 +12,7 @@ PhaseBanner
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `level` | true |  | string | 
+ `children` | true | `````` | node | 
+ `level` | true | `````` | string | 
 
 

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -68,8 +68,8 @@ Radio preselected & disabled
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `className` |  | undefined | string | 
- `inline` |  | false | bool | 
+ `children` | true | `````` | node | 
+ `className` |  | ```undefined``` | string | 
+ `inline` |  | ```false``` | bool | 
 
 

--- a/components/search-box/README.md
+++ b/components/search-box/README.md
@@ -30,6 +30,6 @@ import GridCol from '@govuk-react/grid-col';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `placeholder` |  | undefined | string | 
+ `placeholder` |  | ```undefined``` | string | 
 
 

--- a/components/select/README.md
+++ b/components/select/README.md
@@ -76,11 +76,11 @@ import { SelectInput } '@govuk-react/select';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `errorText` |  | undefined | string | 
- `hint` |  | undefined | string | 
- `input` |  | {} | shape[object Object] | 
- `label` | true |  | string | 
- `meta` |  | {} | shape[object Object] | 
+ `children` | true | `````` | node | 
+ `errorText` |  | ```undefined``` | string | 
+ `hint` |  | ```undefined``` | string | 
+ `input` |  | ```{}``` | shape[object Object] | 
+ `label` | true | `````` | string | 
+ `meta` |  | ```{}``` | shape[object Object] | 
 
 

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -12,8 +12,8 @@ Table
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `body` | true |  | node | 
- `caption` |  | undefined | string | 
- `head` |  | undefined | node | 
+ `body` | true | `````` | node | 
+ `caption` |  | ```undefined``` | string | 
+ `head` |  | ```undefined``` | node | 
 
 

--- a/components/text-area/README.md
+++ b/components/text-area/README.md
@@ -43,9 +43,9 @@ const meta = {
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `children` | true |  | node | 
- `hint` |  | undefined | string | 
- `input` |  | {} | shape[object Object] | 
- `meta` |  | {} | shape[object Object] | 
+ `children` | true | `````` | node | 
+ `hint` |  | ```undefined``` | string | 
+ `input` |  | ```{}``` | shape[object Object] | 
+ `meta` |  | ```{}``` | shape[object Object] | 
 
 

--- a/components/top-nav/README.md
+++ b/components/top-nav/README.md
@@ -12,12 +12,12 @@ TopNav
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `active` |  | undefined | number | 
- `bgColor` |  | BLACK | string | 
- `children` |  | undefined | node | 
- `color` |  | WHITE | string | 
- `company` |  | undefined | node | 
- `search` |  | false | node | 
- `serviceTitle` |  | undefined | node | 
+ `active` |  | ```undefined``` | number | 
+ `bgColor` |  | ```BLACK``` | string | 
+ `children` |  | ```undefined``` | node | 
+ `color` |  | ```WHITE``` | string | 
+ `company` |  | ```undefined``` | node | 
+ `search` |  | ```false``` | node | 
+ `serviceTitle` |  | ```undefined``` | node | 
 
 

--- a/components/unordered-list/README.md
+++ b/components/unordered-list/README.md
@@ -40,6 +40,6 @@ import ListItem from '@govuk-react/list-item';
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `listStyleType` |  | undefined | string | CSS value for `list-style-type`
+ `listStyleType` |  | ```undefined``` | string | CSS value for `list-style-type`
 
 

--- a/packages/api-docs/src/markdown/generateProp.js
+++ b/packages/api-docs/src/markdown/generateProp.js
@@ -2,9 +2,8 @@ import generatePropType from './generatePropType';
 import generatePropDefaultValue from './generatePropDefaultValue';
 
 export default function generateProp(propName, prop) {
-  return ` \`${propName}\` | ${prop.required ? 'true' : ''} | ${
-    prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : ''
-  } | ${prop.type ? generatePropType(prop.type) : ''} | ${
-    prop.description ? `${prop.description}` : ''
-  }`;
+  const defaultValue = prop.defaultValue ? generatePropDefaultValue(prop.defaultValue) : '';
+  const propType = prop.type ? generatePropType(prop.type) : '';
+  const description = prop.description ? prop.description : '';
+  return ` \`${propName}\` | ${prop.required ? 'true' : ''} | \`\`\`${defaultValue}\`\`\` | ${propType} | ${description}`;
 }

--- a/packages/api-docs/src/markdown/generatePropDefaultValue.js
+++ b/packages/api-docs/src/markdown/generatePropDefaultValue.js
@@ -1,3 +1,8 @@
 export default function generatePropDefaultValue(value) {
-  return `${value.value}`;
+  /**
+   * Format default props to be on one line in order
+   * to render vartypes like objects in Markdown tables
+   */
+  const formattedValue = value.value.replace(/\n|\r/g, ' ');
+  return `${formattedValue}`;
 }


### PR DESCRIPTION
Markdown tables don’t support multiline cells, meaning defaultTypes such as objects, that were returned on multiple lines would break our auto-generated readme docs. This change removes line-returns and carriage-returns from defaultProp values ensuring `objects` render on one line and in our documentation. yey!

This change also wraps rendered defaultProps in markdown code comments.

* [x] Documentation
* [x] Tests
* [x] Ready to be merged