### PR TITLE
Feature/adjust topnav mobile border

### DIFF
--- a/components/top-nav/src/__snapshots__/test.js.snap
+++ b/components/top-nav/src/__snapshots__/test.js.snap
@@ -33,7 +33,7 @@ exports[`TopNav matches snapshot: enzyme.mount 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  width: calc(100% - 15px);
+  width: calc(100% - 30px);
   max-width: 960px;
   padding: 10px 15px;
   box-sizing: border-box;
@@ -162,7 +162,7 @@ exports[`TopNav matches snapshot: enzyme.mount 1`] = `
   border-bottom: 10px solid #005ea5;
   max-width: 960px;
   margin: 0 auto;
-  width: calc(100% - 15px);
+  width: calc(100% - 30px);
 }
 
 @media only screen and (min-width:641px) {
@@ -376,7 +376,7 @@ exports[`TopNav with icon title: icon title 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  width: calc(100% - 15px);
+  width: calc(100% - 30px);
   max-width: 960px;
   padding: 10px 15px;
   box-sizing: border-box;
@@ -459,7 +459,7 @@ exports[`TopNav with icon title: icon title 1`] = `
   border-bottom: 10px solid #005ea5;
   max-width: 960px;
   margin: 0 auto;
-  width: calc(100% - 15px);
+  width: calc(100% - 30px);
 }
 
 @media only screen and (min-width:641px) {

--- a/components/top-nav/src/atoms/bottom-nav-wrapper/index.js
+++ b/components/top-nav/src/atoms/bottom-nav-wrapper/index.js
@@ -9,7 +9,7 @@ const BottomNavWrapper = styled('div')({
   borderBottom: `10px solid ${BLUE}`,
   maxWidth: '960px',
   margin: '0 auto',
-  width: `calc(100% - ${SPACING.SCALE_3})`,
+  width: `calc(100% - ${SPACING.SCALE_5})`,
   [MEDIA_QUERIES.LARGESCREEN]: {
     width: `calc(100% - ${SPACING.SCALE_6})`,
   },

--- a/components/top-nav/src/atoms/top-nav-inner/index.js
+++ b/components/top-nav/src/atoms/top-nav-inner/index.js
@@ -7,7 +7,7 @@ import {
 const TopNavInner = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  width: `calc(100% - ${SPACING.SCALE_3})`,
+  width: `calc(100% - ${SPACING.SCALE_5})`,
   maxWidth: '960px',
   padding: `${SPACING.SCALE_2} ${SPACING.SCALE_3}`,
   boxSizing: 'border-box',


### PR DESCRIPTION
* [x] Documentation
* [x] Tests
* [x] Ready to be merged

Fix TopNav bottom blue-bar to match GDS styling by increasing the spacing scale used.

<img width="350" alt="current" src="https://user-images.githubusercontent.com/657572/41242756-47337692-6d98-11e8-9d16-71a5a5170d38.png">
<img width="350" alt="govuk" src="https://user-images.githubusercontent.com/657572/41242757-47584012-6d98-11e8-924b-4d1a7a7b41d0.png">
