### PR TITLE
Feature/hidden text margins bg color

### DIFF
--- a/API.md
+++ b/API.md
@@ -558,11 +558,93 @@ import Paragraph from '@govuk-react/paragraph';
 
 ### References
 - https://govuk-elements.herokuapp.com/typography/#typography-hidden-text
+- https://github.com/alphagov/govuk-frontend/blob/master/src/components/details/_details.scss
 
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `summaryText` |  | ```''``` | string | 
+ `children` |  | ```undefined``` | node | The nodes that will be displayed within the InsetText component
+ `summaryText` | true | `````` | string | Text for the summary button link e.g. Help with nationality
+
+
+InsetText
+=========
+
+### Import
+```js
+  import InsetText from '@govuk-react/inset-text';
+```
+<!-- STORY -->
+
+### Usage
+
+
+Simple
+```jsx
+import Paragraph from '@govuk-react/paragraph';
+
+<InsetText>
+ <Paragraph mb={0}>Hello</Paragraph>
+</InsetText>
+```
+
+Narrow border
+```jsx
+import Paragraph from '@govuk-react/paragraph';
+
+<InsetText isNarrow>
+ <Paragraph mb={0}>Hello</Paragraph>
+</InsetText>
+```
+
+### References
+- https://govuk-elements.herokuapp.com/typography/#typography-inset-text
+- https://github.com/alphagov/govuk-frontend/blob/master/src/components/inset-text/_inset-text.scss
+- https://github.com/alphagov/govuk_elements/blob/master/packages/govuk-elements-sass/public/sass/elements/_panels.scss
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `isNarrow` |  | ```false``` | bool | Renders a narrow border following GDS guides if set to true
+
+
+Paragraph
+=========
+
+### Import
+```js
+  import Paragraph from '@govuk-react/paragraph';
+```
+<!-- STORY -->
+
+### Usage
+
+Supports bold, italic and links in Markdown ONLY.
+This is to ensure we follow GDS as closely as possible.
+It is worth noting that GDS recommends avoiding bold and italics.
+
+Simple Usage with markdown
+```jsx
+<Paragraph>Lorem ipsum **dolor** sit *amet* with [some link](https://google.com)</Paragraph>
+```
+
+As supporting text
+```jsx
+<Paragraph supportingText>Lorem ipsum **dolor** sit *amet* with [some link](https://google.com)</Paragraph>
+```
+
+### References
+- https://govuk-elements.herokuapp.com/typography/#typography-body-copy
+
+### TODO
+- Add test for supporting text
+- Add test for rendering supported markdown components
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` |  | ```''``` | node | Text content supporting markdown
+ `supportingText` |  | ```false``` | bool | Is this paragraph supporting text for another element?
 
 
 HintText

--- a/components/hidden-text/README.md
+++ b/components/hidden-text/README.md
@@ -21,10 +21,12 @@ import Paragraph from '@govuk-react/paragraph';
 
 ### References
 - https://govuk-elements.herokuapp.com/typography/#typography-hidden-text
+- https://github.com/alphagov/govuk-frontend/blob/master/src/components/details/_details.scss
 
 ### Properties
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
- `summaryText` |  | ```''``` | string | 
+ `children` |  | ```undefined``` | node | The nodes that will be displayed within the InsetText component
+ `summaryText` | true | `````` | string | Text for the summary button link e.g. Help with nationality
 
 

--- a/components/hidden-text/package.json
+++ b/components/hidden-text/package.json
@@ -3,8 +3,9 @@
   "version": "0.2.5",
   "dependencies": {
     "@govuk-react/constants": "^0.2.2",
-    "@govuk-react/inset-text": "^0.2.5",
-    "@govuk-react/paragraph": "^0.2.5",
+    "@govuk-react/hoc": "^0.2.4",
+    "@govuk-react/inset-text": "^0.2.4",
+    "@govuk-react/paragraph": "^0.2.4",
     "govuk-colours": "^1.0.3"
   },
   "peerDependencies": {

--- a/components/hidden-text/src/__snapshots__/test.js.snap
+++ b/components/hidden-text/src/__snapshots__/test.js.snap
@@ -84,6 +84,33 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
   margin: 0;
 }
 
+.emotion-2 > p > code {
+  padding: 0.2em 0.4em;
+  margin: 0px;
+  font-size: 85%;
+  background-color: rgba(27,31,35,0.05);
+  border-radius: 3px;
+}
+
+.emotion-2 > pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: #f6f8fa;
+  border-radius: 3px;
+}
+
+.emotion-2 > pre > code {
+  display: inline;
+  padding: 0px;
+  margin: 0px;
+  border: 0px;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+}
+
 @media only screen and (min-width:641px) {
   .emotion-2 {
     font-size: 19px;
@@ -107,6 +134,33 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
 
 .emotion-6 > p {
   margin: 0;
+}
+
+.emotion-6 > p > code {
+  padding: 0.2em 0.4em;
+  margin: 0px;
+  font-size: 85%;
+  background-color: rgba(27,31,35,0.05);
+  border-radius: 3px;
+}
+
+.emotion-6 > pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: #f6f8fa;
+  border-radius: 3px;
+}
+
+.emotion-6 > pre > code {
+  display: inline;
+  padding: 0px;
+  margin: 0px;
+  border: 0px;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
 }
 
 @media only screen and (min-width:641px) {
@@ -177,6 +231,8 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                           "emphasis",
                           "strong",
                           "link",
+                          "inlineCode",
+                          "code",
                         ]
                       }
                       className="emotion-4"
@@ -197,6 +253,8 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                             "emphasis",
                             "strong",
                             "link",
+                            "inlineCode",
+                            "code",
                           ]
                         }
                         astPlugins={Array []}
@@ -245,6 +303,8 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                           "emphasis",
                           "strong",
                           "link",
+                          "inlineCode",
+                          "code",
                         ]
                       }
                       className="emotion-8"
@@ -266,6 +326,8 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                             "emphasis",
                             "strong",
                             "link",
+                            "inlineCode",
+                            "code",
                           ]
                         }
                         astPlugins={Array []}

--- a/components/hidden-text/src/__snapshots__/test.js.snap
+++ b/components/hidden-text/src/__snapshots__/test.js.snap
@@ -26,7 +26,7 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
 }
 
 .emotion-1:focus {
-  outline: calc(3px + 1px) solid #ffbf47;
+  outline: 4px solid #ffbf47;
   background: #ffbf47;
 }
 

--- a/components/hidden-text/src/__snapshots__/test.js.snap
+++ b/components/hidden-text/src/__snapshots__/test.js.snap
@@ -84,33 +84,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
   margin: 0;
 }
 
-.emotion-2 > p > code {
-  padding: 0.2em 0.4em;
-  margin: 0px;
-  font-size: 85%;
-  background-color: rgba(27,31,35,0.05);
-  border-radius: 3px;
-}
-
-.emotion-2 > pre {
-  padding: 16px;
-  overflow: auto;
-  font-size: 85%;
-  line-height: 1.45;
-  background-color: #f6f8fa;
-  border-radius: 3px;
-}
-
-.emotion-2 > pre > code {
-  display: inline;
-  padding: 0px;
-  margin: 0px;
-  border: 0px;
-  overflow: visible;
-  line-height: inherit;
-  word-wrap: normal;
-}
-
 @media only screen and (min-width:641px) {
   .emotion-2 {
     font-size: 19px;
@@ -134,33 +107,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
 
 .emotion-6 > p {
   margin: 0;
-}
-
-.emotion-6 > p > code {
-  padding: 0.2em 0.4em;
-  margin: 0px;
-  font-size: 85%;
-  background-color: rgba(27,31,35,0.05);
-  border-radius: 3px;
-}
-
-.emotion-6 > pre {
-  padding: 16px;
-  overflow: auto;
-  font-size: 85%;
-  line-height: 1.45;
-  background-color: #f6f8fa;
-  border-radius: 3px;
-}
-
-.emotion-6 > pre > code {
-  display: inline;
-  padding: 0px;
-  margin: 0px;
-  border: 0px;
-  overflow: visible;
-  line-height: inherit;
-  word-wrap: normal;
 }
 
 @media only screen and (min-width:641px) {
@@ -231,8 +177,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                           "emphasis",
                           "strong",
                           "link",
-                          "inlineCode",
-                          "code",
                         ]
                       }
                       className="emotion-4"
@@ -253,8 +197,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                             "emphasis",
                             "strong",
                             "link",
-                            "inlineCode",
-                            "code",
                           ]
                         }
                         astPlugins={Array []}
@@ -303,8 +245,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                           "emphasis",
                           "strong",
                           "link",
-                          "inlineCode",
-                          "code",
                         ]
                       }
                       className="emotion-8"
@@ -326,8 +266,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                             "emphasis",
                             "strong",
                             "link",
-                            "inlineCode",
-                            "code",
                           ]
                         }
                         astPlugins={Array []}

--- a/components/hidden-text/src/__snapshots__/test.js.snap
+++ b/components/hidden-text/src/__snapshots__/test.js.snap
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
+.emotion-13 {
+  margin-bottom: 20px;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-13 {
+    margin-bottom: 30px;
+  }
+}
+
 .emotion-1 {
   display: inline-block;
   cursor: pointer;
@@ -16,8 +26,8 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
 }
 
 .emotion-1:focus {
-  outline: 3px solid #ffbf47;
-  outline-offset: -1px;
+  outline: calc(3px + 1px) solid #ffbf47;
+  background: #ffbf47;
 }
 
 .emotion-0 {
@@ -27,13 +37,13 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
   text-decoration-skip-ink: none;
 }
 
-.emotion-11 {
-  margin-bottom: 20px;
+.emotion-8 {
+  margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
-  .emotion-11 {
-    margin-bottom: 30px;
+  .emotion-8 {
+    margin-bottom: 0;
   }
 }
 
@@ -43,12 +53,12 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
   border-left-width: 5px;
   border-color: #bfc1c3;
   padding: 15px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-10 {
-    margin-bottom: 30px;
+    margin-bottom: 0;
   }
 }
 
@@ -114,16 +124,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
   }
 }
 
-.emotion-8 {
-  margin-bottom: 0;
-}
-
-@media only screen and (min-width:641px) {
-  .emotion-8 {
-    margin-bottom: 0;
-  }
-}
-
 .emotion-6 {
   font-family: "nta",Arial,sans-serif;
   margin: 0;
@@ -177,67 +177,54 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
 }
 
 <_default>
-  <HiddenText
+  <Styled(HiddenText)
     summaryText="Help with nationality"
   >
-    <details>
-      <Styled(summary)>
-        <summary
-          className="emotion-1"
-        >
-          <Styled(span)>
-            <span
-              className="emotion-0"
-            >
-              Help with nationality
-            </span>
-          </Styled(span)>
-        </summary>
-      </Styled(summary)>
-      <Styled(InsetText)
-        isNarrow={true}
+    <HiddenText
+      className="emotion-13"
+      summaryText="Help with nationality"
+    >
+      <details
+        className="emotion-13"
       >
-        <InsetText
-          className="emotion-11"
-          isNarrow={true}
-        >
-          <Styled(div)
-            className="emotion-11"
-            isNarrow={true}
+        <Styled(summary)>
+          <summary
+            className="emotion-1"
           >
-            <div
-              className="emotion-10"
-            >
-              <Styled(Paragraph)
-                key="paragraphText1"
+            <Styled(span)>
+              <span
+                className="emotion-0"
               >
-                <Paragraph
-                  className="emotion-4"
-                  supportingText={false}
+                Help with nationality
+              </span>
+            </Styled(span)>
+          </summary>
+        </Styled(summary)>
+        <Styled(InsetText)
+          isNarrow={true}
+          mb={0}
+        >
+          <InsetText
+            className="emotion-8"
+            isNarrow={true}
+            mb={0}
+          >
+            <Styled(div)
+              className="emotion-8"
+              isNarrow={true}
+              mb={0}
+            >
+              <div
+                className="emotion-10"
+              >
+                <Styled(Paragraph)
+                  key="paragraphText1"
                 >
-                  <Styled(ReactMarkdown)
-                    allowedTypes={
-                      Array [
-                        "paragraph",
-                        "emphasis",
-                        "strong",
-                        "link",
-                        "inlineCode",
-                        "code",
-                      ]
-                    }
+                  <Paragraph
                     className="emotion-4"
-                    escapeHtml={false}
-                    renderers={
-                      Object {
-                        "link": [Function],
-                      }
-                    }
-                    skipHtml={true}
-                    source="If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."
                     supportingText={false}
                   >
-                    <ReactMarkdown
+                    <Styled(ReactMarkdown)
                       allowedTypes={
                         Array [
                           "paragraph",
@@ -248,11 +235,8 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                           "code",
                         ]
                       }
-                      astPlugins={Array []}
-                      className="emotion-2"
+                      className="emotion-4"
                       escapeHtml={false}
-                      plugins={Array []}
-                      rawSourcePos={false}
                       renderers={
                         Object {
                           "link": [Function],
@@ -260,57 +244,59 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                       }
                       skipHtml={true}
                       source="If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."
-                      sourcePos={false}
                       supportingText={false}
-                      transformLinkUri={[Function]}
                     >
-                      <div
+                      <ReactMarkdown
+                        allowedTypes={
+                          Array [
+                            "paragraph",
+                            "emphasis",
+                            "strong",
+                            "link",
+                            "inlineCode",
+                            "code",
+                          ]
+                        }
+                        astPlugins={Array []}
                         className="emotion-2"
-                        key="root-1-1"
+                        escapeHtml={false}
+                        plugins={Array []}
+                        rawSourcePos={false}
+                        renderers={
+                          Object {
+                            "link": [Function],
+                          }
+                        }
+                        skipHtml={true}
+                        source="If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."
+                        sourcePos={false}
+                        supportingText={false}
+                        transformLinkUri={[Function]}
                       >
-                        <p
-                          key="paragraph-1-1"
+                        <div
+                          className="emotion-2"
+                          key="root-1-1"
                         >
-                          If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
-                        </p>
-                      </div>
-                    </ReactMarkdown>
-                  </Styled(ReactMarkdown)>
-                </Paragraph>
-              </Styled(Paragraph)>
-              <Styled(Paragraph)
-                key="paragraphText2"
-                mb={0}
-              >
-                <Paragraph
-                  className="emotion-8"
+                          <p
+                            key="paragraph-1-1"
+                          >
+                            If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
+                          </p>
+                        </div>
+                      </ReactMarkdown>
+                    </Styled(ReactMarkdown)>
+                  </Paragraph>
+                </Styled(Paragraph)>
+                <Styled(Paragraph)
+                  key="paragraphText2"
                   mb={0}
-                  supportingText={false}
                 >
-                  <Styled(ReactMarkdown)
-                    allowedTypes={
-                      Array [
-                        "paragraph",
-                        "emphasis",
-                        "strong",
-                        "link",
-                        "inlineCode",
-                        "code",
-                      ]
-                    }
+                  <Paragraph
                     className="emotion-8"
-                    escapeHtml={false}
                     mb={0}
-                    renderers={
-                      Object {
-                        "link": [Function],
-                      }
-                    }
-                    skipHtml={true}
-                    source="We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."
                     supportingText={false}
                   >
-                    <ReactMarkdown
+                    <Styled(ReactMarkdown)
                       allowedTypes={
                         Array [
                           "paragraph",
@@ -321,12 +307,9 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                           "code",
                         ]
                       }
-                      astPlugins={Array []}
-                      className="emotion-6"
+                      className="emotion-8"
                       escapeHtml={false}
                       mb={0}
-                      plugins={Array []}
-                      rawSourcePos={false}
                       renderers={
                         Object {
                           "link": [Function],
@@ -334,29 +317,56 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
                       }
                       skipHtml={true}
                       source="We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."
-                      sourcePos={false}
                       supportingText={false}
-                      transformLinkUri={[Function]}
                     >
-                      <div
+                      <ReactMarkdown
+                        allowedTypes={
+                          Array [
+                            "paragraph",
+                            "emphasis",
+                            "strong",
+                            "link",
+                            "inlineCode",
+                            "code",
+                          ]
+                        }
+                        astPlugins={Array []}
                         className="emotion-6"
-                        key="root-1-1"
+                        escapeHtml={false}
+                        mb={0}
+                        plugins={Array []}
+                        rawSourcePos={false}
+                        renderers={
+                          Object {
+                            "link": [Function],
+                          }
+                        }
+                        skipHtml={true}
+                        source="We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."
+                        sourcePos={false}
+                        supportingText={false}
+                        transformLinkUri={[Function]}
                       >
-                        <p
-                          key="paragraph-1-1"
+                        <div
+                          className="emotion-6"
+                          key="root-1-1"
                         >
-                          We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-                        </p>
-                      </div>
-                    </ReactMarkdown>
-                  </Styled(ReactMarkdown)>
-                </Paragraph>
-              </Styled(Paragraph)>
-            </div>
-          </Styled(div)>
-        </InsetText>
-      </Styled(InsetText)>
-    </details>
-  </HiddenText>
+                          <p
+                            key="paragraph-1-1"
+                          >
+                            We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+                          </p>
+                        </div>
+                      </ReactMarkdown>
+                    </Styled(ReactMarkdown)>
+                  </Paragraph>
+                </Styled(Paragraph)>
+              </div>
+            </Styled(div)>
+          </InsetText>
+        </Styled(InsetText)>
+      </details>
+    </HiddenText>
+  </Styled(HiddenText)>
 </_default>
 `;

--- a/components/hidden-text/src/index.js
+++ b/components/hidden-text/src/index.js
@@ -46,6 +46,7 @@ const StyledSummary = styled('summary')({
  *
  * ### References
  * - https://govuk-elements.herokuapp.com/typography/#typography-hidden-text
+ * - https://github.com/alphagov/govuk-frontend/blob/master/src/components/details/_details.scss
  */
 const HiddenText = ({ summaryText, children, ...props }) => (
   <details {...props}>
@@ -56,12 +57,13 @@ const HiddenText = ({ summaryText, children, ...props }) => (
 
 HiddenText.defaultProps = {
   children: undefined,
-  summaryText: '',
 };
 
 HiddenText.propTypes = {
+  /**  The nodes that will be displayed within the InsetText component */
   children: PropTypes.node,
-  summaryText: PropTypes.string,
+  /** Text for the summary button link e.g. Help with nationality */
+  summaryText: PropTypes.string.isRequired,
 };
 
 export default withWhiteSpace({ marginBottom: 6 })(HiddenText);

--- a/components/hidden-text/src/index.js
+++ b/components/hidden-text/src/index.js
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 import InsetText from '@govuk-react/inset-text';
 import { LINK_COLOUR, LINK_HOVER_COLOUR, FOCUS_COLOUR } from 'govuk-colours';
 import { FOCUS_WIDTH, FONT_SIZE, SPACING, NTA_LIGHT } from '@govuk-react/constants';
+import { withWhiteSpace } from '@govuk-react/hoc';
 
 const StyledSpan = styled('span')({
   textDecoration: 'underline',
@@ -23,8 +24,9 @@ const StyledSummary = styled('summary')({
     color: LINK_HOVER_COLOUR,
   },
   ':focus': {
-    outline: `${FOCUS_WIDTH} solid ${FOCUS_COLOUR}`,
-    outlineOffset: '-1px',
+    outline: `calc(${FOCUS_WIDTH} + 1px) solid ${FOCUS_COLOUR}`,
+    // outlineOffset: '-1px', In alpha/govuk-frontend but causes arrow icon to be hidden when open
+    background: FOCUS_COLOUR,
   },
 });
 
@@ -45,19 +47,21 @@ const StyledSummary = styled('summary')({
  * ### References
  * - https://govuk-elements.herokuapp.com/typography/#typography-hidden-text
  */
-const HiddenText = ({ summaryText, ...props }) => (
-  <details>
+const HiddenText = ({ summaryText, children, ...props }) => (
+  <details {...props}>
     <StyledSummary><StyledSpan>{summaryText}</StyledSpan></StyledSummary>
-    <InsetText isNarrow {...props} />
+    <InsetText mb={0} isNarrow>{ children }</InsetText>
   </details>
 );
 
 HiddenText.defaultProps = {
+  children: undefined,
   summaryText: '',
 };
 
 HiddenText.propTypes = {
+  children: PropTypes.node,
   summaryText: PropTypes.string,
 };
 
-export default HiddenText;
+export default withWhiteSpace({ marginBottom: 6 })(HiddenText);

--- a/components/hidden-text/src/index.js
+++ b/components/hidden-text/src/index.js
@@ -7,6 +7,8 @@ import { LINK_COLOUR, LINK_HOVER_COLOUR, FOCUS_COLOUR } from 'govuk-colours';
 import { FOCUS_WIDTH, FONT_SIZE, SPACING, NTA_LIGHT } from '@govuk-react/constants';
 import { withWhiteSpace } from '@govuk-react/hoc';
 
+const HIDDEN_TEXT_FOCUS_WIDTH = `${parseInt(FOCUS_WIDTH.split('px')[0], 10) + 1}px`;
+
 const StyledSpan = styled('span')({
   textDecoration: 'underline',
   textDecorationSkipInk: 'none',
@@ -24,7 +26,7 @@ const StyledSummary = styled('summary')({
     color: LINK_HOVER_COLOUR,
   },
   ':focus': {
-    outline: `calc(${FOCUS_WIDTH} + 1px) solid ${FOCUS_COLOUR}`,
+    outline: `${HIDDEN_TEXT_FOCUS_WIDTH} solid ${FOCUS_COLOUR}`,
     // outlineOffset: '-1px', In alpha/govuk-frontend but causes arrow icon to be hidden when open
     background: FOCUS_COLOUR,
   },


### PR DESCRIPTION
**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged

### Update HiddenText to align with [Details component](https://design-system.service.gov.uk/components/details/) margins and focus background colour

- Add hoc as a package to HiddenText
- Add whiteSpace on details only and remove from inset text to align alpha/govuk-frontend
- Spread props to details instead of InsetText so that the withWhiteSpace can be applied.
- Change background colour to FOCUS_COLOUR based on new GDS design system at https://design-system.service.gov.uk/components/details/
- Update HiddenText snapshot
