### PR TITLE
fix meta.initial proptype for forms

### DIFF
--- a/components/file-upload/src/index.js
+++ b/components/file-upload/src/index.js
@@ -102,7 +102,7 @@ FileUpload.propTypes = {
     dirty: PropTypes.bool,
     dirtySinceLastSubmit: PropTypes.bool,
     error: PropTypes.any,
-    initial: PropTypes.bool,
+    initial: PropTypes.any,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,
     submitError: PropTypes.any,

--- a/components/input-field/src/index.js
+++ b/components/input-field/src/index.js
@@ -87,7 +87,7 @@ InputField.propTypes = {
     dirty: PropTypes.bool,
     dirtySinceLastSubmit: PropTypes.bool,
     error: PropTypes.any,
-    initial: PropTypes.bool,
+    initial: PropTypes.any,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,
     submitError: PropTypes.any,

--- a/components/multi-choice/src/index.js
+++ b/components/multi-choice/src/index.js
@@ -91,7 +91,7 @@ MultiChoice.propTypes = {
     dirty: PropTypes.bool,
     dirtySinceLastSubmit: PropTypes.bool,
     error: PropTypes.any,
-    initial: PropTypes.bool,
+    initial: PropTypes.any,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,
     submitError: PropTypes.any,

--- a/components/select/src/index.js
+++ b/components/select/src/index.js
@@ -146,7 +146,7 @@ Select.propTypes = {
     dirty: PropTypes.bool,
     dirtySinceLastSubmit: PropTypes.bool,
     error: PropTypes.any,
-    initial: PropTypes.bool,
+    initial: PropTypes.any,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,
     submitError: PropTypes.any,

--- a/components/text-area/src/index.js
+++ b/components/text-area/src/index.js
@@ -109,7 +109,7 @@ TextArea.propTypes = {
     dirty: PropTypes.bool,
     dirtySinceLastSubmit: PropTypes.bool,
     error: PropTypes.any,
-    initial: PropTypes.bool,
+    initial: PropTypes.any,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,
     submitError: PropTypes.any,


### PR DESCRIPTION
Fixes console errors on form elements, should be `PropTypes.any` https://github.com/final-form/final-form#initial-any

Example of error: https://codesandbox.io/s/nwmy8k3xrl

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
