### PR TITLE
Supporting Header Component

### DIFF
--- a/components/supporting-header/README.md
+++ b/components/supporting-header/README.md
@@ -1,0 +1,33 @@
+SupportingHeader
+================
+
+### Import
+```js
+  import SupportingHeader from '@govuk-react/supporting-header';
+```
+<!-- STORY -->
+
+### Usage
+
+Simple
+```jsx
+<SupportingHeader>Heading text</SupportingHeader>
+```
+
+With another header
+```jsx
+import { H1 } from '@govuk-react/header';
+
+<SupportingHeader>Supporting header text</SupportingHeader>
+<H1>Main header text</H1>
+```
+
+### References
+- https://govuk-elements.herokuapp.com/typography/
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` | true | `````` | string | Text to be rendered as a supporting header
+
+

--- a/components/supporting-header/package.json
+++ b/components/supporting-header/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@govuk-react/supporting-header",
+  "version": "0.2.7",
+  "dependencies": {
+    "@govuk-react/constants": "^0.2.7",
+    "@govuk-react/hoc": "^0.2.7",
+    "govuk-colours": "^1.0.3"
+  },
+  "peerDependencies": {
+    "emotion": ">=9",
+    "prop-types": ">=15",
+    "react": ">=16.2.0",
+    "react-emotion": ">=9"
+  },
+  "scripts": {
+    "build": "npm run build:lib && npm run build:es",
+    "build:lib": "rimraf lib && babel src -d lib --source-maps",
+    "build:es": "rimraf es && cross-env BABEL_ENV=es babel src -d es --source-maps",
+    "docs": "doc-component ./lib/index.js ./README.md"
+  },
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "author": "Toby Brancher",
+  "license": "MIT",
+  "homepage": "https://github.com/UKHomeOffice/govuk-react#readme",
+  "description": "govuk-react: A port of the govuk-frontend components for React using Emotion.",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/supporting-header/src/__snapshots__/test.js.snap
+++ b/components/supporting-header/src/__snapshots__/test.js.snap
@@ -14,13 +14,16 @@ exports[`SupportingHeader matches wrapper snapshot 1`] = `
 .emotion-0 {
   font-family: "nta",Arial,sans-serif;
   font-size: 20px;
+  line-height: 1.11111;
   color: #6f777b;
+  padding-bottom: 7px;
   margin-bottom: 0;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-0 {
     font-size: 27px;
+    padding-bottom: 7px;
   }
 }
 

--- a/components/supporting-header/src/__snapshots__/test.js.snap
+++ b/components/supporting-header/src/__snapshots__/test.js.snap
@@ -23,7 +23,7 @@ exports[`SupportingHeader matches wrapper snapshot 1`] = `
 @media only screen and (min-width:641px) {
   .emotion-0 {
     font-size: 27px;
-    padding-bottom: 7px;
+    padding-bottom: 6px;
   }
 }
 

--- a/components/supporting-header/src/__snapshots__/test.js.snap
+++ b/components/supporting-header/src/__snapshots__/test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SupportingHeader matches wrapper snapshot 1`] = `
+.emotion-1 {
+  margin-bottom: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-1 {
+    margin-bottom: 0;
+  }
+}
+
+.emotion-0 {
+  font-family: "nta",Arial,sans-serif;
+  font-size: 20px;
+  color: #6f777b;
+  margin-bottom: 0;
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    font-size: 27px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    margin-bottom: 0;
+  }
+}
+
+<Styled(SupportingHeader)>
+  <SupportingHeader
+    className="emotion-1"
+  >
+    <Styled(span)
+      className="emotion-1"
+    >
+      <span
+        className="emotion-0"
+      >
+        Heading text
+      </span>
+    </Styled(span)>
+  </SupportingHeader>
+</Styled(SupportingHeader)>
+`;

--- a/components/supporting-header/src/fixtures.js
+++ b/components/supporting-header/src/fixtures.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { text } from '@storybook/addon-knobs/react';
+
+import SupportingHeader from '.';
+
+const exampleHeading = 'Heading text';
+
+const SupportingHeaderWithKnobs = () => (
+  <SupportingHeader>{text('children', exampleHeading)}</SupportingHeader>
+);
+
+export default SupportingHeader;
+
+export {
+  exampleHeading,
+  SupportingHeaderWithKnobs,
+};

--- a/components/supporting-header/src/index.js
+++ b/components/supporting-header/src/index.js
@@ -13,7 +13,7 @@ import {
 // The line-height and padding for supporting headers does not follow any pre-existing patterns
 const customLineHeight = '1.11111';
 const smallPaddingBottom = '7px';
-const largePaddingBottom = '7px';
+const largePaddingBottom = '6px';
 
 const StyledHeader = styled('span')({
   fontFamily: NTA_LIGHT,

--- a/components/supporting-header/src/index.js
+++ b/components/supporting-header/src/index.js
@@ -1,0 +1,51 @@
+import styled from 'react-emotion';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { GREY_1 } from 'govuk-colours';
+import { withWhiteSpace } from '@govuk-react/hoc';
+import {
+  FONT_SIZE,
+  LINE_HEIGHT,
+  MEDIA_QUERIES,
+  NTA_LIGHT,
+} from '@govuk-react/constants';
+
+const StyledHeader = styled('span')({
+  fontFamily: NTA_LIGHT,
+  fontSize: FONT_SIZE.SIZE_20,
+  lineHeight: LINE_HEIGHT.SIZE_20,
+  color: GREY_1,
+  [MEDIA_QUERIES.LARGESCREEN]: {
+    fontSize: FONT_SIZE.SIZE_27,
+    lineHeight: LINE_HEIGHT.SIZE_27,
+  },
+});
+
+/**
+ *
+ * ### Usage
+ *
+ * Simple
+ * ```jsx
+ * <SupportingHeader>Heading text</SupportingHeader>
+ * ```
+ *
+ * With another header
+ * ```jsx
+ * import { H1 } from '@govuk-react/header';
+ *
+ * <SupportingHeader>Supporting header text</SupportingHeader>
+ * <H1>Main header text</H1>
+ * ```
+ *
+ * ### References
+ * - https://govuk-elements.herokuapp.com/typography/
+ */
+const SupportingHeader = props => <StyledHeader {...props} />;
+
+SupportingHeader.propTypes = {
+  /** Text to be rendered as a supporting header */
+  children: PropTypes.string.isRequired,
+};
+
+export default withWhiteSpace({ marginBottom: 0 })(SupportingHeader);

--- a/components/supporting-header/src/index.js
+++ b/components/supporting-header/src/index.js
@@ -10,14 +10,21 @@ import {
   NTA_LIGHT,
 } from '@govuk-react/constants';
 
+// The line-height and padding for supporting headers does not follow any pre-existing patterns
+const customLineHeight = '1.11111';
+const smallPaddingBottom = '7px';
+const largePaddingBottom = '7px';
+
 const StyledHeader = styled('span')({
   fontFamily: NTA_LIGHT,
   fontSize: FONT_SIZE.SIZE_20,
-  lineHeight: LINE_HEIGHT.SIZE_20,
+  lineHeight: customLineHeight,
   color: GREY_1,
+  paddingBottom: smallPaddingBottom,
   [MEDIA_QUERIES.LARGESCREEN]: {
     fontSize: FONT_SIZE.SIZE_27,
     lineHeight: LINE_HEIGHT.SIZE_27,
+    paddingBottom: largePaddingBottom,
   },
 });
 

--- a/components/supporting-header/src/stories.js
+++ b/components/supporting-header/src/stories.js
@@ -1,0 +1,30 @@
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs/react';
+import { WithDocsCustom } from '@govuk-react/storybook-components';
+
+import { H1 } from '@govuk-react/header';
+
+import SupportingHeader, { SupportingHeaderWithKnobs } from './fixtures';
+import ReadMe from '../README.md';
+
+const stories = storiesOf('Typography/SupportingHeader', module);
+const examples = storiesOf('Typography/SupportingHeader/Examples', module);
+
+stories.addDecorator(withKnobs);
+stories.addDecorator(WithDocsCustom(ReadMe));
+
+stories.add('Component default', () => (
+  <SupportingHeaderWithKnobs />
+));
+
+examples.add('Component default', () => (
+  <Fragment>
+    <SupportingHeader>
+      Supporting header text
+    </SupportingHeader>
+    <H1>
+      Main header text
+    </H1>
+  </Fragment>
+));

--- a/components/supporting-header/src/test.js
+++ b/components/supporting-header/src/test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SupportingHeader, { exampleHeading } from './fixtures';
+
+describe('SupportingHeader', () => {
+  let wrapper;
+
+  it('renders without crashing', () => {
+    wrapper = mount(<SupportingHeader>{exampleHeading}</SupportingHeader>);
+  });
+
+  it('matches wrapper snapshot', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@govuk-react/search-box": "*",
     "@govuk-react/select": "*",
     "@govuk-react/storybook-components": "*",
+    "@govuk-react/supporting-header": "*",
     "@govuk-react/table": "*",
     "@govuk-react/text-area": "*",
     "@govuk-react/top-nav": "*",

--- a/packages/govuk-react/package.json
+++ b/packages/govuk-react/package.json
@@ -41,6 +41,7 @@
     "@govuk-react/related-items": "^0.2.7",
     "@govuk-react/search-box": "^0.2.7",
     "@govuk-react/select": "^0.2.7",
+    "@govuk-react/supporting-header": "^0.2.7",
     "@govuk-react/table": "^0.2.7",
     "@govuk-react/text-area": "^0.2.7",
     "@govuk-react/top-nav": "^0.2.7",

--- a/packages/govuk-react/src/index.js
+++ b/packages/govuk-react/src/index.js
@@ -43,6 +43,7 @@ export { default as TopNav } from '@govuk-react/top-nav';
 export { default as Table } from '@govuk-react/table';
 export { default as LeadParagraph } from '@govuk-react/lead-paragraph';
 export { default as WarningText } from '@govuk-react/warning-text';
+export { default as SupportingHeader } from '@govuk-react/supporting-header';
 
 export { H1, H2, H3, H4, H5, H6 } from '@govuk-react/header';
 

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -35,6 +35,7 @@
     "@govuk-react/related-items": "^0.2.7",
     "@govuk-react/search-box": "^0.2.7",
     "@govuk-react/select": "^0.2.7",
+    "@govuk-react/supporting-header": "^0.2.7",
     "@govuk-react/table": "^0.2.7",
     "@govuk-react/text-area": "^0.2.7",
     "@govuk-react/top-nav": "^0.2.7",


### PR DESCRIPTION
Component for rendering supporting header text. Closes #99 and #328.

Despite the discussion on #99 this is a separate component, and thus can be used alongside headings or by itself.

* [x] Documentation
* [x] Tests
* [x] Ready to be merged

Screenshots of stories;
![screen shot 2018-07-05 at 15 15 13](https://user-images.githubusercontent.com/657572/42328632-b3d144d8-8066-11e8-9659-c2c7276ea74b.png)
![screen shot 2018-07-05 at 15 15 20](https://user-images.githubusercontent.com/657572/42328640-b61ed106-8066-11e8-8928-5a83197ab433.png)


