### PR TITLE
Feature/improve grid col

### DIFF
--- a/components/grid-col/src/__snapshots__/test.js.snap
+++ b/components/grid-col/src/__snapshots__/test.js.snap
@@ -2,16 +2,14 @@
 
 exports[`GridCol matches snapshot: enzyme.mount 1`] = `
 .emotion-0 {
-  background: transparent;
-  margin: 0 0 15px;
-  text-indent: 0px;
+  margin-bottom: 15px;
   box-sizing: border-box;
 }
 
 @media only screen and (min-width:641px) {
   .emotion-0 {
-    width: 100%;
-    margin: 0 15px;
+    margin-right: 15px;
+    margin-left: 15px;
   }
 
   .emotion-0:first-child {
@@ -20,6 +18,16 @@ exports[`GridCol matches snapshot: enzyme.mount 1`] = `
 
   .emotion-0:last-child {
     margin-right: 0;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .emotion-0 {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    width: auto;
   }
 }
 

--- a/components/grid-col/src/index.js
+++ b/components/grid-col/src/index.js
@@ -25,13 +25,14 @@ const StyledColumn = styled('div')(
       },
     },
   },
-  ({ hideContent }) => ({
-    textIndent: hideContent ? '-999em' : undefined,
-    backgroundColor: hideContent ? '#7DADD3' : undefined,
-    backgroundImage: hideContent
-      ? 'repeating-linear-gradient(180deg, #7DADD3, #7DADD3 15px, #B7CFE1 15px, #B7CFE1 30px)'
-      : undefined,
-  }),
+  ({ hideContent }) => {
+    if (!hideContent) { return false; }
+    return ({
+      textIndent: '-999em',
+      backgroundColor: '#7DADD3',
+      backgroundImage: 'repeating-linear-gradient(180deg, #7DADD3, #7DADD3 15px, #B7CFE1 15px, #B7CFE1 30px)',
+    });
+  },
   (...args) => {
     let widthValue = 'auto';
     let hasRequestedWidth = false;

--- a/components/grid-col/src/index.js
+++ b/components/grid-col/src/index.js
@@ -33,11 +33,11 @@ const StyledColumn = styled('div')(
       backgroundImage: 'repeating-linear-gradient(180deg, #7DADD3, #7DADD3 15px, #B7CFE1 15px, #B7CFE1 30px)',
     });
   },
-  (...args) => {
+  (props) => {
     let widthValue = 'auto';
     let hasRequestedWidth = false;
 
-    Object.entries(args[0]).forEach(([key, value]) => {
+    Object.entries(props).forEach(([key, value]) => {
       if (colValues[key] && value === true) {
         widthValue = colValues[key];
         hasRequestedWidth = true;

--- a/components/grid-col/src/index.js
+++ b/components/grid-col/src/index.js
@@ -3,15 +3,20 @@ import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import { GUTTER_HALF, MEDIA_QUERIES, SPACING } from '@govuk-react/constants';
 
+const colValues = {
+  columnOneThird: '33.3333%',
+  columnTwoThirds: '66.6667%',
+  columnOneQuarter: '25%',
+  columnOneHalf: '50%',
+};
+
 const StyledColumn = styled('div')(
   {
-    background: 'transparent',
-    margin: `0 0 ${SPACING.SCALE_3}`,
-    textIndent: '0',
+    marginBottom: SPACING.SCALE_3,
     boxSizing: 'border-box',
     [MEDIA_QUERIES.LARGESCREEN]: {
-      width: '100%',
-      margin: `0 ${GUTTER_HALF}`,
+      marginRight: GUTTER_HALF,
+      marginLeft: GUTTER_HALF,
       ':first-child': {
         marginLeft: 0,
       },
@@ -27,26 +32,23 @@ const StyledColumn = styled('div')(
       ? 'repeating-linear-gradient(180deg, #7DADD3, #7DADD3 15px, #B7CFE1 15px, #B7CFE1 30px)'
       : undefined,
   }),
-  ({ columnOneThird }) => ({
-    [MEDIA_QUERIES.LARGESCREEN]: {
-      width: columnOneThird ? '33.3333%' : undefined,
-    },
-  }),
-  ({ columnTwoThirds }) => ({
-    [MEDIA_QUERIES.LARGESCREEN]: {
-      width: columnTwoThirds ? '66.6667%' : undefined,
-    },
-  }),
-  ({ columnOneQuarter }) => ({
-    [MEDIA_QUERIES.LARGESCREEN]: {
-      width: columnOneQuarter ? '25%' : undefined,
-    },
-  }),
-  ({ columnOneHalf }) => ({
-    [MEDIA_QUERIES.LARGESCREEN]: {
-      width: columnOneHalf ? '50%' : undefined,
-    },
-  }),
+  (...args) => {
+    let widthValue = 'auto';
+    let hasRequestedWidth = false;
+
+    Object.entries(args[0]).forEach(([key, value]) => {
+      if (colValues[key] && value === true) {
+        widthValue = colValues[key];
+        hasRequestedWidth = true;
+      }
+    });
+    return ({
+      [MEDIA_QUERIES.LARGESCREEN]: {
+        flexGrow: hasRequestedWidth ? 0 : 1,
+        width: widthValue,
+      },
+    });
+  },
 );
 
 /**

--- a/components/grid-col/src/stories.js
+++ b/components/grid-col/src/stories.js
@@ -110,3 +110,17 @@ examples.add('Quarters', () => (
     </GridRow>
   </Fragment>
 ));
+
+examples.add('One Quarter and autoFill', () => (
+  <Fragment>
+    <GridRow>
+      <GridCol hideContent columnOneQuarter>
+        <p>content</p>
+      </GridCol>
+      <GridCol hideContent autoFill>
+        <p>content</p>
+      </GridCol>
+    </GridRow>
+  </Fragment>
+));
+

--- a/components/grid-col/src/stories.js
+++ b/components/grid-col/src/stories.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { WithDocsCustom } from '@govuk-react/storybook-components';
 
@@ -38,89 +38,77 @@ stories.add('Component default', () => (
 ));
 
 examples.add('Column Halves', () => (
-  <Fragment>
-    <GridRow>
-      <GridCol hideContent columnOneHalf>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneHalf>
-        <p>content</p>
-      </GridCol>
-    </GridRow>
-  </Fragment>
+  <GridRow>
+    <GridCol hideContent columnOneHalf>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneHalf>
+      <p>content</p>
+    </GridCol>
+  </GridRow>
 ));
 
 examples.add('Column Thirds', () => (
-  <Fragment>
-    <GridRow>
-      <GridCol hideContent columnOneThird>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneThird>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneThird>
-        <p>content</p>
-      </GridCol>
-    </GridRow>
-  </Fragment>
+  <GridRow>
+    <GridCol hideContent columnOneThird>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneThird>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneThird>
+      <p>content</p>
+    </GridCol>
+  </GridRow>
 ));
 
 examples.add('Column Two Thirds / One Third', () => (
-  <Fragment>
-    <GridRow>
-      <GridCol hideContent columnTwoThirds>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneThird>
-        <p>content</p>
-      </GridCol>
-    </GridRow>
-  </Fragment>
+  <GridRow>
+    <GridCol hideContent columnTwoThirds>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneThird>
+      <p>content</p>
+    </GridCol>
+  </GridRow>
 ));
 
 examples.add('Column One Third / Two Thirds', () => (
-  <Fragment>
-    <GridRow>
-      <GridCol hideContent columnOneThird>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnTwoThirds>
-        <p>content</p>
-      </GridCol>
-    </GridRow>
-  </Fragment>
+  <GridRow>
+    <GridCol hideContent columnOneThird>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnTwoThirds>
+      <p>content</p>
+    </GridCol>
+  </GridRow>
 ));
 
 examples.add('Quarters', () => (
-  <Fragment>
-    <GridRow>
-      <GridCol hideContent columnOneQuarter>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneQuarter>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneQuarter>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent columnOneQuarter>
-        <p>content</p>
-      </GridCol>
-    </GridRow>
-  </Fragment>
+  <GridRow>
+    <GridCol hideContent columnOneQuarter>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneQuarter>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneQuarter>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent columnOneQuarter>
+      <p>content</p>
+    </GridCol>
+  </GridRow>
 ));
 
 examples.add('One Quarter and autoFill', () => (
-  <Fragment>
-    <GridRow>
-      <GridCol hideContent columnOneQuarter>
-        <p>content</p>
-      </GridCol>
-      <GridCol hideContent autoFill>
-        <p>content</p>
-      </GridCol>
-    </GridRow>
-  </Fragment>
+  <GridRow>
+    <GridCol hideContent columnOneQuarter>
+      <p>content</p>
+    </GridCol>
+    <GridCol hideContent autoFill>
+      <p>content</p>
+    </GridCol>
+  </GridRow>
 ));
 


### PR DESCRIPTION
Fixes #377 

- Removes 100% width
- Sets flex grow value to 0 if element has a requested col width, otherwise it is set to 1, allowing it to auto-expand
- Reduces a lot of un-required CSS by only rendering css props if specific props are passed
- Only applies desired margin values to avoid overriding values potentially requested elsewhere (like margin top or bottom

* [x] Documentation
* [x] Tests
* [x] Ready to be merged