### PR TITLE
Apply more sensible minHeight value of '10px' as a fallback

### DIFF
--- a/components/loading-box/src/__snapshots__/test.js.snap
+++ b/components/loading-box/src/__snapshots__/test.js.snap
@@ -4,7 +4,7 @@ exports[`LoadingBox matches wrapper loading: wrapper loading 1`] = `
 .emotion-14 {
   position: relative;
   padding-bottom: 2px;
-  min-height: 100px;
+  min-height: 10px;
 }
 
 .emotion-13 {
@@ -120,9 +120,7 @@ exports[`LoadingBox matches wrapper loading: wrapper loading 1`] = `
   timeIn={800}
   timeOut={200}
 >
-  <Styled(div)
-    loading={true}
-  >
+  <Styled(div)>
     <div
       className="emotion-14"
     >

--- a/components/loading-box/src/__snapshots__/test.js.snap
+++ b/components/loading-box/src/__snapshots__/test.js.snap
@@ -120,7 +120,9 @@ exports[`LoadingBox matches wrapper loading: wrapper loading 1`] = `
   timeIn={800}
   timeOut={200}
 >
-  <Styled(div)>
+  <Styled(div)
+    loading={true}
+  >
     <div
       className="emotion-14"
     >

--- a/components/loading-box/src/index.js
+++ b/components/loading-box/src/index.js
@@ -8,13 +8,11 @@ import { BLACK, WHITE } from 'govuk-colours';
 
 const spinnerClassName = 'icon-loading';
 
-const StyledContainer = styled('div')(({
-  loading,
-}) => ({
+const StyledContainer = styled('div')({
   position: 'relative',
   paddingBottom: '2px',
-  minHeight: loading ? '100px' : undefined,
-}));
+  minHeight: '10px',
+});
 
 const Innerwrap = styled('div')(({
   timeIn,
@@ -161,7 +159,7 @@ const LoadingBox = ({
   timeOut,
   ...props
 }) => (
-  <StyledContainer loading={loading} {...props}>
+  <StyledContainer {...props}>
     <CSSTransition timeout={timeOut} classNames="fade" in={loading} unmountOnExit>
       <Innerwrap
         backgroundColor={backgroundColor}

--- a/components/loading-box/src/index.js
+++ b/components/loading-box/src/index.js
@@ -8,11 +8,13 @@ import { BLACK, WHITE } from 'govuk-colours';
 
 const spinnerClassName = 'icon-loading';
 
-const StyledContainer = styled('div')({
+const StyledContainer = styled('div')(({
+  loading,
+}) => ({
   position: 'relative',
   paddingBottom: '2px',
-  minHeight: '100px',
-});
+  minHeight: loading ? '100px' : undefined,
+}));
 
 const Innerwrap = styled('div')(({
   timeIn,
@@ -159,7 +161,7 @@ const LoadingBox = ({
   timeOut,
   ...props
 }) => (
-  <StyledContainer {...props}>
+  <StyledContainer loading={loading} {...props}>
     <CSSTransition timeout={timeOut} classNames="fade" in={loading} unmountOnExit>
       <Innerwrap
         backgroundColor={backgroundColor}

--- a/components/loading-box/src/stories.js
+++ b/components/loading-box/src/stories.js
@@ -122,7 +122,7 @@ examples.add('LoadingBox (long)', () => (
   </LoadingBox>
 ));
 
-examples.add('with children that have short height (minHeight 100px)', () => (
+examples.add('with children that have short height (minHeight 10px)', () => (
   <LoadingBox loading>
     Lorem ipsum dolor sit amet
   </LoadingBox>


### PR DESCRIPTION
**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Ready to be merged

Solution: Apply more sensible min-height of 10px as a fall back so at least the spinner will be displayed.

closes #381 