### PR TITLE
Proposed fix for #339

### DIFF
--- a/components/hidden-text/src/__snapshots__/test.js.snap
+++ b/components/hidden-text/src/__snapshots__/test.js.snap
@@ -12,7 +12,6 @@ exports[`hidden text matches the HiddenText snapshot: hidden text 1`] = `
 }
 
 .emotion-1 {
-  display: inline-block;
   cursor: pointer;
   color: #005ea5;
   font-family: "nta",Arial,sans-serif;

--- a/components/hidden-text/src/index.js
+++ b/components/hidden-text/src/index.js
@@ -15,7 +15,6 @@ const StyledSpan = styled('span')({
 });
 
 const StyledSummary = styled('summary')({
-  display: 'inline-block',
   cursor: 'pointer',
   color: LINK_COLOUR,
   fontFamily: NTA_LIGHT,


### PR DESCRIPTION
Having replicated #339 in Firefox (Mac) locally, this is a proposed fix - simply removing the display statement - but of course this will only be acceptable if it doesn't have any adverse effects where the component is used.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
