### PR TITLE
Feature/adjust implementation homepage storybook

### DIFF
--- a/components/radio/src/index.js
+++ b/components/radio/src/index.js
@@ -1,6 +1,3 @@
-// https://github.com/alphagov/govuk-frontend/blob/master/src/components/radios/_radios.scss
-// https://github.com/alphagov/govuk_elements/blob/master/assets/sass/elements/_forms.scss
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';

--- a/packages/storybook-components/src/ReadMeHidePreview.js
+++ b/packages/storybook-components/src/ReadMeHidePreview.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withDocs } from 'storybook-readme';
+
+const PreviewComponent = ({ children }) => (
+  <div
+    style={{
+      display: 'none',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const ReadMeHidePreview = withDocs({
+  PreviewComponent,
+});
+
+PreviewComponent.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ReadMeHidePreview;

--- a/packages/storybook-components/src/index.js
+++ b/packages/storybook-components/src/index.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 export { default as FinalFormWrapper } from './FinalFormWrapper';
 export { default as WithDocsCustom } from './WithDocsCustom';
+export { default as ReadMeHidePreview } from './ReadMeHidePreview';

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -35,6 +35,7 @@
     "@govuk-react/related-items": "^0.2.7",
     "@govuk-react/search-box": "^0.2.7",
     "@govuk-react/select": "^0.2.9",
+    "@govuk-react/storybook-components": "^0.2.7",
     "@govuk-react/supporting-header": "^0.2.9",
     "@govuk-react/table": "^0.2.7",
     "@govuk-react/text-area": "^0.2.9",

--- a/packages/storybook/src/stories/index.js
+++ b/packages/storybook/src/stories/index.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { ReadMeHidePreview } from '@govuk-react/storybook-components';
 import 'normalize.css';
 import './styles.css';
-import readme from '../../../../README.md';
+import ReadMe from '../../../../README.md';
 
-// eslint-disable-next-line react/no-danger
-storiesOf(' Welcome', module).add('to govuk-react', () => <div style={{ padding: '10px' }} className="markdown-body" dangerouslySetInnerHTML={{ __html: readme }} />);
+const stories = storiesOf(' Welcome', module);
+stories.addDecorator(ReadMeHidePreview(ReadMe));
+
+stories.add('to govuk-react', () => <div />);
 
 const req = require.context('../../../../', true, /(packages|components)\/[^/]+\/src\/([^/]+\/)*stories.js$/);
 req.keys().forEach(req);


### PR DESCRIPTION
Update the implementation of the readme on homepage to not use `dangerouslySetInnerHTML`

Added sneaky adjustment to remove duplicate comment in radio button source.

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
