### PR TITLE
Add break-word to table cells

### DIFF
--- a/components/table/src/__snapshots__/test.js.snap
+++ b/components/table/src/__snapshots__/test.js.snap
@@ -48,6 +48,7 @@ exports[`Table matches snapshot for example: example mount 1`] = `
   padding: 0.63158em 1.05263em 0.47368em 0;
   text-align: left;
   text-transform: none;
+  word-break: break-word;
 }
 
 .emotion-1:last-child {
@@ -155,6 +156,7 @@ exports[`Table matches snapshot for exampleWithHead: exampleWithHead mount 1`] =
   padding: 0.63158em 1.05263em 0.47368em 0;
   text-align: left;
   text-transform: none;
+  word-break: break-word;
 }
 
 .emotion-1:last-child {

--- a/components/table/src/atoms/Cell/index.js
+++ b/components/table/src/atoms/Cell/index.js
@@ -24,6 +24,7 @@ const CellInner = styled('td')(({
   padding: '0.63158em 1.05263em 0.47368em 0',
   textAlign: alignRight ? 'right' : 'left',
   textTransform: 'none',
+  wordBreak: 'break-word',
   ':last-child': {
     paddingRight: 0,
   },


### PR DESCRIPTION
Fixes #414 

This PR adds `break-word` to table cells to ensure table cells to not render larger than their intended size.

It has been mentioned that this adjustment deviates from GDS, as the table cells there do no specify `break-word`, I am assuming this is because this issue has not been experienced by any of their implementations, or if it has, it has been overridden during its implementation.

Before;
![screen shot 2018-09-19 at 14 36 39](https://user-images.githubusercontent.com/657572/45757709-ec560780-bc1b-11e8-844e-abfd9c62d0b2.png)

After;
![screen shot 2018-09-19 at 14 37 17](https://user-images.githubusercontent.com/657572/45757717-f0822500-bc1b-11e8-955d-1079cab4fb09.png)

* [x] Ready to be merged
