### PR TITLE
Change regex in link-renderer.js in Paragraph

### DIFF
--- a/components/paragraph/src/link-renderer.js
+++ b/components/paragraph/src/link-renderer.js
@@ -6,7 +6,7 @@ import Anchor from './atoms/anchor';
 // Support react-router links
 // https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
 const LinkRenderer = ({ href, children }) => (
-  href.match(/^\//)
+  /^\//.test(href)
     ? <Link to={href}>{children}</Link>
     : <Anchor href={href}>{children}</Anchor>
 );


### PR DESCRIPTION
converted str.match(regex) to regex.test(str), could have become a problem should this library ever convert to TypeScript

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
