### PR TITLE
Bring error-summary test coverage to 100%

### DIFF
--- a/components/error-summary/src/test.js
+++ b/components/error-summary/src/test.js
@@ -57,6 +57,16 @@ describe('error summary', () => {
     });
   });
 
+  it('renders with defaultProps', () => {
+    const wrapper = mount(<ErrorSummary
+      heading={heading}
+      errors={errors}
+    />);
+    const anchor = wrapper.find('Anchor').first();
+    expect(anchor.props().onClick).toBeInstanceOf(Function);
+    anchor.simulate('click');
+  });
+
   it('matches the ErrorSummary snapshot', () => {
     expect(wrapperErrorSummary).toMatchSnapshot('error summary');
   });


### PR DESCRIPTION
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
